### PR TITLE
[patch] Oscar - Small error in merging for the RequestType /all endpoint inside form

### DIFF
--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestForm.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestForm.js
@@ -36,7 +36,7 @@ function RecommendationRequestForm({
     };
     const getRequestTypes = async () => {
       try {
-        const response = await fetch("/api/requesttype/all");
+        const response = await fetch("/api/requesttypes/all");
         const data = await response.json();
         setRecommendationTypes(data);
       } catch (error) {

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.js
@@ -28,7 +28,7 @@ describe("RecommendationRequestForm tests", () => {
       .onGet("/api/admin/users/professors")
       .reply(200, usersFixtures.userOnly);
     axiosMock
-      .onGet("/api/requesttype/all")
+      .onGet("/api/requesttypes/all")
       .reply(200, recommendationTypeFixtures.fourTypes);
     global.fetch = jest.fn();
   });
@@ -98,7 +98,7 @@ describe("RecommendationRequestForm tests", () => {
 
     // Assert: Check that fetch was called with the correct URLs
     expect(global.fetch).toHaveBeenCalledWith("/api/admin/users/professors");
-    expect(global.fetch).toHaveBeenCalledWith("/api/requesttype/all");
+    expect(global.fetch).toHaveBeenCalledWith("/api/requesttypes/all");
     await waitFor(() => {
       usersFixtures.twoProfessors.forEach((professor) => {
         expect(screen.getByText(professor.fullName)).toBeInTheDocument();


### PR DESCRIPTION
in my form PR, the route was /requesttype/all and I created the requesttype/all endpoint but when it was merged, the requesttypes routes were already in main, but this wasn't switched. Tiny fix to make sure everything is working

Dokku: https://rec-obenedek20-dev.dokku-08.cs.ucsb.edu
