### PR TITLE
pc - hotfix to boolean fields in users table (to address deployment error)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/rec/entities/User.java
@@ -35,9 +35,9 @@ public class User {
   private String locale;
   private String hostedDomain;
   @Builder.Default
-  private boolean admin=false;
+  private Boolean admin=false;
   @Builder.Default
-  private boolean student=false;
+  private Boolean student=false;
   @Builder.Default
-  private boolean professor=false;
+  private Boolean professor=false;
 }

--- a/src/main/resources/db/migration/changes/Users.json
+++ b/src/main/resources/db/migration/changes/Users.json
@@ -38,7 +38,8 @@
                       "nullable": false
                     },
                     "name": "ADMIN",
-                    "type": "BOOLEAN"
+                    "type": "BOOLEAN",
+                    "defaultValue": "false"
                   }
                 },
                 {
@@ -101,13 +102,15 @@
                 {
                   "column": {
                     "name": "PROFESSOR",
-                    "type": "BOOLEAN"
+                    "type": "BOOLEAN",
+                    "defaultValue": "false"
                   }
                 },
                 {
                   "column": {
                     "name": "STUDENT",
-                    "type": "BOOLEAN"
+                    "type": "BOOLEAN",
+                    "defaultValue": "false"
                   }
                 }]
               ,


### PR DESCRIPTION
This PR is an attempt at a hot fix for this error that occurred when deploying the main branch:

```
Error was Null value was assigned to a property [class edu.ucsb.cs156.rec.entities.User.professor] of primitive type
```

We add a default value `false` in the database migration file, and change the type from `boolean` to `Boolean`.